### PR TITLE
Add PHP support using Peachpie

### DIFF
--- a/Common/Properties/AssemblyInfo.cs
+++ b/Common/Properties/AssemblyInfo.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("MirrorSharp.Benchmarks")]
 [assembly: InternalsVisibleTo("MirrorSharp.FSharp")]
 [assembly: InternalsVisibleTo("MirrorSharp.VisualBasic")]
+[assembly: InternalsVisibleTo("MirrorSharp.Php")]
 [assembly: InternalsVisibleTo("MirrorSharp.Owin")]
 [assembly: InternalsVisibleTo("MirrorSharp.Testing")]
 [assembly: InternalsVisibleTo("MirrorSharp.Tests.Roslyn1")]

--- a/MirrorSharp.sln
+++ b/MirrorSharp.sln
@@ -30,6 +30,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NuGet.Common.props = NuGet.Common.props
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Php", "Php\Php.csproj", "{C40A0924-7A1C-4488-ADF1-3B57ACEFD892}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Tests.Shared\MirrorSharp.Tests.Shared.projitems*{0a9078a1-bd26-4dc7-87bb-ded125f6218b}*SharedItemsImports = 13
@@ -77,6 +79,10 @@ Global
 		{C8076D77-4C5A-450E-AF3F-9E37A8B512D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8076D77-4C5A-450E-AF3F-9E37A8B512D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8076D77-4C5A-450E-AF3F-9E37A8B512D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C40A0924-7A1C-4488-ADF1-3B57ACEFD892}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C40A0924-7A1C-4488-ADF1-3B57ACEFD892}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C40A0924-7A1C-4488-ADF1-3B57ACEFD892}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C40A0924-7A1C-4488-ADF1-3B57ACEFD892}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Php/Advanced/IPhpSession.cs
+++ b/Php/Advanced/IPhpSession.cs
@@ -1,0 +1,13 @@
+using JetBrains.Annotations;
+using Pchp.CodeAnalysis;
+
+namespace MirrorSharp.Php.Advanced
+{
+    /// <summary>Represents a user session based on the Peachpie PHP compiler.</summary>
+    [PublicAPI]
+    public interface IPhpSession {
+        /// <summary>Object containing the syntax and semantic information.</summary>
+        /// <note>We work directly with the <see cref="PhpCompilation"/> object, because the project system is not yet implemented in Peachpie.</note>
+        [PublicAPI, NotNull] PhpCompilation Compilation { get; set; }
+    }
+}

--- a/Php/Advanced/IPhpSession.cs
+++ b/Php/Advanced/IPhpSession.cs
@@ -1,8 +1,7 @@
 using JetBrains.Annotations;
 using Pchp.CodeAnalysis;
 
-namespace MirrorSharp.Php.Advanced
-{
+namespace MirrorSharp.Php.Advanced {
     /// <summary>Represents a user session based on the Peachpie PHP compiler.</summary>
     [PublicAPI]
     public interface IPhpSession {

--- a/Php/Advanced/RoslynTypesExtensions.cs
+++ b/Php/Advanced/RoslynTypesExtensions.cs
@@ -5,8 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
-namespace MirrorSharp.Php.Advanced
-{
+namespace MirrorSharp.Php.Advanced {
     /// <summary>Provides the conversion from certain types in the fork of Roslyn used in Peachpie to the standard Roslyn.</summary>
     [PublicAPI]
     public static class RoslynTypesExtensions {

--- a/Php/Advanced/RoslynTypesExtensions.cs
+++ b/Php/Advanced/RoslynTypesExtensions.cs
@@ -1,0 +1,45 @@
+extern alias peachpie;
+using PeachpieRoslyn = peachpie::Microsoft.CodeAnalysis;
+
+using JetBrains.Annotations;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace MirrorSharp.Php.Advanced
+{
+    /// <summary>Provides the conversion from certain types in the fork of Roslyn used in Peachpie to the standard Roslyn.</summary>
+    [PublicAPI]
+    public static class RoslynTypesExtensions {
+        public static TextSpan ToStandardRoslyn(this PeachpieRoslyn.Text.TextSpan span) => new TextSpan(span.Start, span.Length);
+
+        public static LinePosition ToStandardRoslyn(this PeachpieRoslyn.Text.LinePosition position) => new LinePosition(position.Line, position.Character);
+
+        public static LinePositionSpan ToStandardRoslyn(this PeachpieRoslyn.Text.LinePositionSpan span) {
+            return new LinePositionSpan(
+                span.Start.ToStandardRoslyn(),
+                span.End.ToStandardRoslyn());
+        }
+
+        public static Location ToStandardRoslyn(this PeachpieRoslyn.Location location) {
+            return Location.Create(
+                location.SourceTree.FilePath,
+                location.SourceSpan.ToStandardRoslyn(),
+                location.GetLineSpan().Span.ToStandardRoslyn());
+        }
+
+        public static DiagnosticSeverity ToStandardRoslyn(this PeachpieRoslyn.DiagnosticSeverity severity) => (DiagnosticSeverity)(int)severity;
+
+        public static Diagnostic ToStandardRoslyn(this PeachpieRoslyn.Diagnostic diagnostic) {
+            return Diagnostic.Create(
+                diagnostic.Id,
+                "Compiler",
+                diagnostic.GetMessage(),
+                diagnostic.Severity.ToStandardRoslyn(),
+                diagnostic.DefaultSeverity.ToStandardRoslyn(),
+                isEnabledByDefault: false,
+                warningLevel: diagnostic.Severity == PeachpieRoslyn.DiagnosticSeverity.Warning ? 1 : 0,
+                location: diagnostic.Location.ToStandardRoslyn()
+            );
+        }
+    }
+}

--- a/Php/Advanced/WorkSessionExtensions.cs
+++ b/Php/Advanced/WorkSessionExtensions.cs
@@ -1,0 +1,25 @@
+using JetBrains.Annotations;
+using MirrorSharp.Advanced;
+using MirrorSharp.Internal;
+
+namespace MirrorSharp.Php.Advanced {
+    /// <summary>Provides PHP-related extensions to the <see cref="IWorkSession" />.</summary>
+    [PublicAPI]
+    public static class WorkSessionExtensions {
+        /// <summary>Specifies whether the <see cref="IWorkSession" /> is using PHP.</summary>
+        /// <param name="session">The session</param>
+        /// <returns><c>true</c> if the session is using PHP; otherwise, <c>false</c></returns>
+        public static bool IsPhp([NotNull] this IWorkSession session) {
+            Argument.NotNull(nameof(session), session);
+            return ((WorkSession)session).LanguageSession is IPhpSession;
+        }
+
+        /// <summary>Returns PHP session associated with the <see cref="IWorkSession" />, if any; throws otherwise.</summary>
+        /// <param name="session">The session</param>
+        /// <returns><see cref="IPhpSession" /> if the session is using PHP</returns>
+        public static IPhpSession Php(this IWorkSession session) {
+            Argument.NotNull(nameof(session), session);
+            return (IPhpSession)((WorkSession)session).LanguageSession;
+        }
+    }
+}

--- a/Php/Internal/PhpLanguage.cs
+++ b/Php/Internal/PhpLanguage.cs
@@ -1,7 +1,6 @@
 using MirrorSharp.Internal.Abstraction;
 
-namespace MirrorSharp.Php.Internal
-{
+namespace MirrorSharp.Php.Internal {
     internal class PhpLanguage : ILanguage {
         public const string Name = "PHP";
 

--- a/Php/Internal/PhpLanguage.cs
+++ b/Php/Internal/PhpLanguage.cs
@@ -1,0 +1,20 @@
+using MirrorSharp.Internal.Abstraction;
+
+namespace MirrorSharp.Php.Internal
+{
+    internal class PhpLanguage : ILanguage {
+        public const string Name = "PHP";
+
+        private readonly MirrorSharpPhpOptions _options;
+
+        public PhpLanguage(MirrorSharpPhpOptions options) {
+            _options = options;
+        }
+
+        public ILanguageSessionInternal CreateSession(string text) {
+            return new PhpSession(text, _options);
+        }
+
+        string ILanguage.Name => Name;
+    }
+}

--- a/Php/Internal/PhpSession.cs
+++ b/Php/Internal/PhpSession.cs
@@ -1,0 +1,84 @@
+extern alias peachpie;
+using PeachpieRoslyn = peachpie::Microsoft.CodeAnalysis;
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Text;
+using MirrorSharp.Internal.Abstraction;
+using MirrorSharp.Php.Advanced;
+using Pchp.CodeAnalysis;
+
+namespace MirrorSharp.Php.Internal
+{
+    internal class PhpSession : ILanguageSessionInternal, IPhpSession {
+        private const string AssemblyName = "app";
+        private const string ScriptFileName = "index.php";
+
+        private string _text;
+        private MirrorSharpPhpOptions _options;
+
+        public PhpSession(string text, MirrorSharpPhpOptions options) {
+            _text = text;
+            _options = options;
+
+            var syntaxTree = PhpSyntaxTree.ParseCode(text, PhpParseOptions.Default, PhpParseOptions.Default, ScriptFileName);
+            Compilation = PhpCompilation.Create(
+                assemblyName: AssemblyName,
+                syntaxTrees: new[] { syntaxTree },
+                references: options.AssemblyReferencePaths.Select(path => PeachpieRoslyn.MetadataReference.CreateFromFile(path)),
+                options: new PhpCompilationOptions(
+                    outputKind: PeachpieRoslyn.OutputKind.ConsoleApplication, // TODO: Store in MirrorSharpPhpOptions
+                    baseDirectory: Environment.CurrentDirectory,
+                    sdkDirectory: null
+                )
+            );
+        }
+
+        public PhpCompilation Compilation { get; set; }
+
+        public string GetText() => _text;
+
+        public void ReplaceText(string newText, int start = 0, int? length = null) {
+            if (length > 0)
+                _text = _text.Remove(start, length.Value);
+            if (newText?.Length > 0)
+                _text = _text.Insert(start, newText);
+
+            var syntaxTree = PhpSyntaxTree.ParseCode(_text, PhpParseOptions.Default, PhpParseOptions.Default, ScriptFileName);
+            Compilation = (PhpCompilation)Compilation.ReplaceSyntaxTree(Compilation.SyntaxTrees.Single(), syntaxTree);
+        }
+
+        public async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(CancellationToken cancellationToken) {
+            var parseDiags = Compilation.GetParseDiagnostics();
+            if (parseDiags.Length > 0) {
+                return parseDiags
+                    .Select(diagnostic => diagnostic.ToStandardRoslyn())
+                    .ToImmutableArray();
+            } else {
+                return (await Compilation.BindAndAnalyseTask())
+                    .Select(diagnostic => diagnostic.ToStandardRoslyn())
+                    .ToImmutableArray();
+            }
+        }
+
+        public bool ShouldTriggerCompletion(int cursorPosition, CompletionTrigger trigger) {
+            return false; // not supported yet
+        }
+
+        public Task<CompletionList> GetCompletionsAsync(int cursorPosition, CompletionTrigger trigger, CancellationToken cancellationToken) {
+            return Task.FromResult(CompletionList.Empty); // not supported yet
+        }
+
+        public Task<CompletionChange> GetCompletionChangeAsync(TextSpan completionSpan, [NotNull] CompletionItem item, CancellationToken cancellationToken) {
+            throw new NotSupportedException(); // not supported yet
+        }
+
+        public void Dispose() {}
+    }
+}

--- a/Php/Internal/PhpSession.cs
+++ b/Php/Internal/PhpSession.cs
@@ -14,8 +14,7 @@ using MirrorSharp.Internal.Abstraction;
 using MirrorSharp.Php.Advanced;
 using Pchp.CodeAnalysis;
 
-namespace MirrorSharp.Php.Internal
-{
+namespace MirrorSharp.Php.Internal {
     internal class PhpSession : ILanguageSessionInternal, IPhpSession {
         private const string AssemblyName = "app";
         private const string ScriptFileName = "index.php";
@@ -75,7 +74,7 @@ namespace MirrorSharp.Php.Internal
                     .Select(diagnostic => diagnostic.ToStandardRoslyn())
                     .ToImmutableArray();
             } else {
-                return (await Compilation.BindAndAnalyseTask())
+                return (await Compilation.BindAndAnalyseTask().ConfigureAwait(false))
                     .Select(diagnostic => diagnostic.ToStandardRoslyn())
                     .ToImmutableArray();
             }

--- a/Php/Internal/PhpSession.cs
+++ b/Php/Internal/PhpSession.cs
@@ -26,7 +26,7 @@ namespace MirrorSharp.Php.Internal
         static PhpSession() {
             CoreCompilation = PhpCompilation.Create(
                 assemblyName: AssemblyName,
-                syntaxTrees: null,
+                syntaxTrees: ImmutableArray<PhpSyntaxTree>.Empty,
                 references: MirrorSharpPhpOptions.AssemblyReferencePaths.Select(path => PeachpieRoslyn.MetadataReference.CreateFromFile(path)),
                 options: new PhpCompilationOptions(
                     outputKind: PeachpieRoslyn.OutputKind.ConsoleApplication,

--- a/Php/MirrorSharpOptionsExtensions.cs
+++ b/Php/MirrorSharpOptionsExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using JetBrains.Annotations;
+using MirrorSharp.Php;
+using MirrorSharp.Php.Internal;
+
+namespace MirrorSharp {
+    /// <summary>Extensions to <see cref="MirrorSharpOptions" /> related to Visual Basic .NET.</summary>
+    [PublicAPI]
+    public static class MirrorSharpOptionsExtensions {
+        /// <summary>Enables and configures PHP .NET support in the <see cref="MirrorSharpOptions" />.</summary>
+        /// <param name="options">Options to configure</param>
+        /// <param name="setup">Setup delegate used to configure <see cref="MirrorSharpPhpOptions" /></param>
+        /// <returns>Value of <paramref name="options" />, for convenience.</returns>
+        [NotNull]
+        public static MirrorSharpOptions EnablePhp([NotNull] this MirrorSharpOptions options, [CanBeNull] Action<MirrorSharpPhpOptions> setup = null) {
+            Argument.NotNull(nameof(options), options);
+            options.Languages.Add(PhpLanguage.Name, () => {
+                var phpOptions = new MirrorSharpPhpOptions();
+                setup?.Invoke(phpOptions);
+                return new PhpLanguage(phpOptions);
+            });
+            return options;
+        }
+    }
+}

--- a/Php/MirrorSharpPhpOptions.cs
+++ b/Php/MirrorSharpPhpOptions.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 
@@ -8,21 +10,37 @@ namespace MirrorSharp.Php
     [PublicAPI]
     public class MirrorSharpPhpOptions {
         /// <summary>Contains the list of assembly reference paths to be used, not configurable.</summary>
-        public static readonly ImmutableArray<string> AssemblyReferencePaths;
-
-        static MirrorSharpPhpOptions() {
-            AssemblyReferencePaths = ImmutableArray.Create(
-                typeof(object).GetTypeInfo().Assembly.Location,                                         // mscorlib
-                typeof(Pchp.Core.Context).GetTypeInfo().Assembly.Location,                              // Peachpie.Runtime
-                typeof(Pchp.Library.Strings).GetTypeInfo().Assembly.Location,                           // Peachpie.Library
-                typeof(Peachpie.Library.XmlDom.XmlDom).GetTypeInfo().Assembly.Location,                 // Peachpie.Library.XmlDom
-                typeof(Peachpie.Library.Scripting.ScriptingProvider).GetTypeInfo().Assembly.Location    // Peachpie.Library.Scripting
-            );
-        }
+        public static readonly ImmutableArray<string> AssemblyReferencePaths = GatherPeachpieReferences();
 
         internal MirrorSharpPhpOptions() { }
 
         /// <summary>Whether to compile in Debug mode.</summary>
         public bool? Debug { get; set; }
+
+        private static ImmutableArray<string> GatherPeachpieReferences() {
+            var refKnownTypes = new[] {
+                typeof(object),                                         // mscorlib
+                typeof(Pchp.Core.Context),                              // Peachpie.Runtime
+                typeof(Pchp.Library.Strings),                           // Peachpie.Library
+                typeof(Peachpie.Library.XmlDom.XmlDom),                 // Peachpie.Library.XmlDom
+                typeof(Peachpie.Library.Scripting.ScriptingProvider)    // Peachpie.Library.Scripting
+            };
+
+            var list = refKnownTypes.Select(type => type.GetTypeInfo().Assembly).Distinct().ToList();
+            var set = new HashSet<Assembly>(list);
+
+            for (int i = 0; i < list.Count; i++) {
+                var assembly = list[i];
+                var refs = assembly.GetReferencedAssemblies();
+                foreach (var refname in refs) {
+                    var refassembly = Assembly.Load(refname);
+                    if (refassembly != null && set.Add(refassembly)) {
+                        list.Add(refassembly);
+                    }
+                }
+            }
+
+            return list.Select(ass => ass.Location).ToImmutableArray();
+        }
     }
 }

--- a/Php/MirrorSharpPhpOptions.cs
+++ b/Php/MirrorSharpPhpOptions.cs
@@ -4,8 +4,7 @@ using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 
-namespace MirrorSharp.Php
-{
+namespace MirrorSharp.Php {
     /// <summary>MirrorSharp options for PHP</summary>
     [PublicAPI]
     public class MirrorSharpPhpOptions {
@@ -29,7 +28,7 @@ namespace MirrorSharp.Php
             var list = refKnownTypes.Select(type => type.GetTypeInfo().Assembly).Distinct().ToList();
             var set = new HashSet<Assembly>(list);
 
-            for (int i = 0; i < list.Count; i++) {
+            for (var i = 0; i < list.Count; i++) {
                 var assembly = list[i];
                 var refs = assembly.GetReferencedAssemblies();
                 foreach (var refname in refs) {

--- a/Php/MirrorSharpPhpOptions.cs
+++ b/Php/MirrorSharpPhpOptions.cs
@@ -1,0 +1,26 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace MirrorSharp.Php
+{
+    /// <summary>MirrorSharp options for PHP</summary>
+    [PublicAPI]
+    public class MirrorSharpPhpOptions {
+        internal MirrorSharpPhpOptions() {
+            AssemblyReferencePaths = ImmutableArray.Create(
+                typeof(object).GetTypeInfo().Assembly.Location,                                         // mscorlib
+                typeof(Pchp.Core.Context).GetTypeInfo().Assembly.Location,                              // Peachpie.Runtime
+                typeof(Pchp.Library.Strings).GetTypeInfo().Assembly.Location,                           // Peachpie.Library
+                typeof(Peachpie.Library.XmlDom.XmlDom).GetTypeInfo().Assembly.Location,                 // Peachpie.Library.XmlDom
+                typeof(Peachpie.Library.Scripting.ScriptingProvider).GetTypeInfo().Assembly.Location    // Peachpie.Library.Scripting
+            );
+        }
+
+        /// <summary>Specifies the list of assembly reference paths to be used.</summary>
+        public ImmutableArray<string> AssemblyReferencePaths { get; set; }
+
+        /// <summary>Whether to compile in Debug mode.</summary>
+        public bool? Debug { get; set; }
+    }
+}

--- a/Php/MirrorSharpPhpOptions.cs
+++ b/Php/MirrorSharpPhpOptions.cs
@@ -7,7 +7,10 @@ namespace MirrorSharp.Php
     /// <summary>MirrorSharp options for PHP</summary>
     [PublicAPI]
     public class MirrorSharpPhpOptions {
-        internal MirrorSharpPhpOptions() {
+        /// <summary>Contains the list of assembly reference paths to be used, not configurable.</summary>
+        public static readonly ImmutableArray<string> AssemblyReferencePaths;
+
+        static MirrorSharpPhpOptions() {
             AssemblyReferencePaths = ImmutableArray.Create(
                 typeof(object).GetTypeInfo().Assembly.Location,                                         // mscorlib
                 typeof(Pchp.Core.Context).GetTypeInfo().Assembly.Location,                              // Peachpie.Runtime
@@ -17,8 +20,7 @@ namespace MirrorSharp.Php
             );
         }
 
-        /// <summary>Specifies the list of assembly reference paths to be used.</summary>
-        public ImmutableArray<string> AssemblyReferencePaths { get; set; }
+        internal MirrorSharpPhpOptions() { }
 
         /// <summary>Whether to compile in Debug mode.</summary>
         public bool? Debug { get; set; }

--- a/Php/Php.csproj
+++ b/Php/Php.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../NuGet.Common.props" />
+
+  <PropertyGroup>
+    <AssemblyName>MirrorSharp.Php</AssemblyName>
+    <RootNamespace>MirrorSharp.Php</RootNamespace>
+    <TargetFrameworks>net46</TargetFrameworks>
+    <VersionPrefix>0.9.2</VersionPrefix>
+    <Description>MirrorSharp PHP support library, implemented using Peachpie. $(DescriptionSuffix)</Description>
+    <PackageTags>PHP;Peachpie;CodeMirror</PackageTags>
+    <DocumentationFile>$(OutDir)\MirrorSharp.Php.xml</DocumentationFile>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Peachpie.CodeAnalysis" Version="0.9.0-*" />
+    <PackageReference Include="Peachpie.App" Version="0.9.0-*" />
+  </ItemGroup>
+
+  <Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Peachpie.Microsoft.CodeAnalysis'">
+        <Aliases>peachpie</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/Php/Properties/AssemblyInfo.cs
+++ b/Php/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+[assembly: InternalsVisibleTo("MirrorSharp.Tests.Roslyn2.Net46")]

--- a/Tests.Roslyn2.Net46/PhpTests.cs
+++ b/Tests.Roslyn2.Net46/PhpTests.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using MirrorSharp.Php.Internal;
+using MirrorSharp.Internal;
+using MirrorSharp.Testing;
+using MirrorSharp.Testing.Internal.Results;
+using Xunit;
+
+// ReSharper disable HeapView.ObjectAllocation
+// ReSharper disable HeapView.BoxingAllocation
+
+namespace MirrorSharp.Tests {
+    public class PhpTests {
+        private static readonly MirrorSharpOptions Options = new MirrorSharpOptions().EnablePhp();
+
+        [Fact]
+        public async void SlowUpdate_ProducesNoDiagnostics_IfCodeIsValid() {
+            var driver = MirrorSharpTestDriver.New(Options, PhpLanguage.Name);
+            var code = @"
+                <?php
+
+                function main() {
+                    echo ""Hello World!"";
+                }
+
+                main();
+            ".Trim().Replace("                ", "");
+            await driver.SendReplaceTextAsync(code);
+            var result = await driver.SendSlowUpdateAsync();
+            Assert.Empty(result.Diagnostics);
+        }
+
+        [Fact]
+        public async void SlowUpdate_ProducesExpectedDiagnostics_IfCodeHasErrors() {
+            var driver = MirrorSharpTestDriver.New(Options, PhpLanguage.Name);
+            await driver.SendReplaceTextAsync("<?php new A;");
+            var result = await driver.SendSlowUpdateAsync();
+            
+            Assert.Equal(
+                new[] { new {
+                    Severity = "warning",
+                    Message = "Class 'A' not found",
+                    Span = new { Start = (int?)10, Length = (int?)1 }
+                } },
+                result.Diagnostics.Select(d => new {
+                    d.Severity,
+                    d.Message,
+                    Span = new { d.Span?.Start, d.Span?.Length }
+                }).ToArray()
+            );
+        }
+    }
+}

--- a/Tests.Roslyn2.Net46/Tests.Roslyn2.Net46.csproj
+++ b/Tests.Roslyn2.Net46/Tests.Roslyn2.Net46.csproj
@@ -33,7 +33,16 @@
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj" />
     <ProjectReference Include="..\FSharp\FSharp.csproj" />
+    <ProjectReference Include="..\Php\Php.csproj" />
     <ProjectReference Include="..\Testing\Testing.csproj" />
     <ProjectReference Include="..\VisualBasic\VisualBasic.csproj" />
   </ItemGroup>
+
+  <Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Peachpie.Microsoft.CodeAnalysis'">
+        <Aliases>peachpie</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/WebAssets/mirrorsharp.js
+++ b/WebAssets/mirrorsharp.js
@@ -8,7 +8,8 @@
           'codemirror-addon-lint-fix',
           'codemirror/addon/hint/show-hint',
           'codemirror/mode/clike/clike',
-          'codemirror/mode/vb/vb'
+          'codemirror/mode/vb/vb',
+          'codemirror/mode/php/php'
         ], factory);
     }
     else if (typeof module === 'object' && module.exports) {
@@ -17,7 +18,8 @@
           require('codemirror-addon-lint-fix'),
           require('codemirror/addon/hint/show-hint'),
           require('codemirror/mode/clike/clike'),
-          require('codemirror/mode/vb/vb')
+          require('codemirror/mode/vb/vb'),
+          require('codemirror/mode/php/php')
         );
     }
     else {
@@ -436,7 +438,8 @@
         const languageModes = {
             'C#': 'text/x-csharp',
             'Visual Basic': 'text/x-vb',
-            'F#': 'text/x-fsharp'
+            'F#': 'text/x-fsharp',
+            'PHP': 'application/x-httpd-php'
         };
 
         var language;

--- a/WebAssets/mirrorsharp.js
+++ b/WebAssets/mirrorsharp.js
@@ -18,8 +18,7 @@
           require('codemirror-addon-lint-fix'),
           require('codemirror/addon/hint/show-hint'),
           require('codemirror/mode/clike/clike'),
-          require('codemirror/mode/vb/vb'),
-          require('codemirror/mode/php/php')
+          require('codemirror/mode/vb/vb')
         );
     }
     else {

--- a/pack-all.bat
+++ b/pack-all.bat
@@ -1,3 +1,3 @@
 @echo off
-powershell "$versionSuffix = '%1'; $output = (Resolve-Path .); @('Common', 'FSharp', 'Owin', 'Testing', 'VisualBasic') | %% { dotnet restore /p:VersionSuffix=$versionSuffix; dotnet pack $_ --version-suffix=$versionSuffix --output $output --configuration Release }"
+powershell "$versionSuffix = '%1'; $output = (Resolve-Path .); @('Common', 'FSharp', 'Owin', 'Testing', 'VisualBasic', 'Php') | %% { dotnet restore /p:VersionSuffix=$versionSuffix; dotnet pack $_ --version-suffix=$versionSuffix --output $output --configuration Release }"
 npm pack WebAssets


### PR DESCRIPTION
Hello, I'm from the @peachpiecompiler team. @bfistein contacted you earlier whether we can add the support of PHP to your SharpLab project. We need to start with mirrorsharp, because SharpLab is dependent on its packages (both NuGet and NPM). Let me know if there are any problems with the PR. Thanks a lot.