### PR TITLE
Don't set CodeMirror language when not explicitely set in server options.

### DIFF
--- a/WebAssets/mirrorsharp.js
+++ b/WebAssets/mirrorsharp.js
@@ -763,7 +763,7 @@
 
         function receiveServerOptions(value) {
             serverOptions = value;
-            if (value.language !== language) {
+            if (value.language !== undefined && value.language !== language) {
                 language = value.language;
                 cm.setOption('mode', languageModes[language]);
             }


### PR DESCRIPTION
Otherwise you always have to set it when sending server options.