### PR TITLE
update FSharp.Compiler.Service to version 30.0.0

### DIFF
--- a/FSharp/FSharp.csproj
+++ b/FSharp/FSharp.csproj
@@ -11,13 +11,13 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Compiler.Service" Version="28.0.0" />
+    <PackageReference Include="FSharp.Compiler.Service" Version="30.0.0" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
   </ItemGroup>
 

--- a/Tests.Roslyn2.NetCore/Tests.Roslyn2.NetCore.csproj
+++ b/Tests.Roslyn2.NetCore/Tests.Roslyn2.NetCore.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Compiler.Service" Version="28.0.0" />
+    <PackageReference Include="FSharp.Compiler.Service" Version="30.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.2.0" />


### PR DESCRIPTION
Hi! New versions of FCS are out and so I figured I'd go ahead and update.  I can't test on my osx machine in this repo (the build fails to nuget warnings around duplicate types:

```
Internal/Handlers/SetOptionsHandler.cs(29,23): error CS0433: The type 'ArrayPool<T>' exists in both 'System.Buffers, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' and 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' [/Users/chethusk/oss/mirrorsharp/Common/Common.csproj]
```

but the code changes build correctly for the new version of FCS.