### PR TITLE
update FCS and FSharp.Core to latest versions

### DIFF
--- a/FSharp/FSharp.csproj
+++ b/FSharp/FSharp.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>MirrorSharp.FSharp</AssemblyName>
     <RootNamespace>MirrorSharp.FSharp</RootNamespace>
     <TargetFrameworks>netstandard2.0; net461</TargetFrameworks>
-    <VersionPrefix>0.16</VersionPrefix>
+    <VersionPrefix>0.17</VersionPrefix>
     <Description>MirrorSharp F# support library. $(DescriptionSuffix)</Description>
     <PackageTags>F#;CodeMirror</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/FSharp/FSharp.csproj
+++ b/FSharp/FSharp.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Compiler.Service" Version="30.0.0" />
-    <PackageReference Include="FSharp.Core" Version="4.6.2" />
+    <PackageReference Include="FSharp.Compiler.Service" Version="32.0.0" />
+    <PackageReference Include="FSharp.Core" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/FSharp/MirrorSharpFSharpOptions.cs
+++ b/FSharp/MirrorSharpFSharpOptions.cs
@@ -13,15 +13,22 @@ namespace MirrorSharp.FSharp {
 
             var corelib = typeof(object).Assembly;
             assemblyPaths.Add(corelib.Location);
+
             // Initial version -- likely to need a lot of adjustment/alignment with other languages
             if (corelib.GetName().Name == "System.Private.CoreLib") {
                 // .NET Core
                 var basePath = Path.GetDirectoryName(corelib.Location);
                 assemblyPaths.Add(Path.Combine(basePath, "mscorlib.dll"));
+                assemblyPaths.Add(Path.Combine(basePath, "netstandard.dll"));
                 assemblyPaths.Add(Path.Combine(basePath, "System.dll"));
+                assemblyPaths.Add(Path.Combine(basePath, "System.Collections.dll"));
+                assemblyPaths.Add(Path.Combine(basePath, "System.IO.dll"));
+                assemblyPaths.Add(Path.Combine(basePath, "System.Net.Requests.dll"));
+                assemblyPaths.Add(Path.Combine(basePath, "System.Net.WebClient.dll"));
                 assemblyPaths.Add(Path.Combine(basePath, "System.Runtime.dll"));
                 assemblyPaths.Add(Path.Combine(basePath, "System.Runtime.Extensions.dll"));
-                assemblyPaths.Add(Path.Combine(basePath, "System.IO.dll"));
+                assemblyPaths.Add(Path.Combine(basePath, "System.Runtime.Numerics.dll"));
+
             }
             assemblyPaths.Add(typeof(EntryPointAttribute).Assembly.Location);
             AssemblyReferencePaths = assemblyPaths.ToImmutable();

--- a/Tests.Roslyn2.NetCore/Tests.Roslyn2.NetCore.csproj
+++ b/Tests.Roslyn2.NetCore/Tests.Roslyn2.NetCore.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Compiler.Service" Version="30.0.0" />
+    <PackageReference Include="FSharp.Compiler.Service" Version="32.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.2.0" />


### PR DESCRIPTION
This included added some new required references to the default resolution set. This will likely need to be expanded, for example for checking .net core scripts in Ionide we include everything in the packs/refs folder, defaulting to the runtime folders.

These reference set changes may be able to be reverted when I release the next version of FCS, but I wanted to get you updated because this version supports the F# 4.7 and preview language features.