### PR TITLE
Allow developer to set a custom web socket url

### DIFF
--- a/AspNetCore/Internal/Middleware.cs
+++ b/AspNetCore/Internal/Middleware.cs
@@ -8,15 +8,29 @@ using MirrorSharp.Internal;
 namespace MirrorSharp.AspNetCore.Internal {
     internal class Middleware : MiddlewareBase {
         private readonly RequestDelegate _next;
+        private readonly MirrorSharpOptions _options;
 
         public Middleware(RequestDelegate next, MirrorSharpOptions options) : base(options) {
             _next = Argument.NotNull(nameof(next), next);
+            _options = options;
         }
 
         public Task InvokeAsync(HttpContext context) {
-            if (!context.WebSockets.IsWebSocketRequest)
-                return _next(context);
 
+            if (!context.WebSockets.IsWebSocketRequest) {
+                return _next(context);
+            }
+
+            if (string.IsNullOrWhiteSpace(_options.WebSocketUrl)) {
+                if (!context.Request.Path.Value.EndsWith("/mirrorsharp", StringComparison.OrdinalIgnoreCase)) {
+                    return _next(context);
+                }
+            } else {
+                if (!context.Request.Path.Value.Equals(_options.WebSocketUrl.Trim(), StringComparison.OrdinalIgnoreCase)) {
+                    return _next(context);
+                }
+            }   
+            
             return StartWebSocketLoopAsync(context);
         }
 

--- a/Common/MirrorSharpOptions.cs
+++ b/Common/MirrorSharpOptions.cs
@@ -35,6 +35,9 @@ namespace MirrorSharp {
         /// <summary>Defines whether the SelfDebug mode is enabled — might reduce performance.</summary>
         public bool SelfDebugEnabled { get; set; }
 
+        /// <summary>Defines the web socket url - e.g. wss://your_app_root/mirrorsharp (default behaviour: accepts any connection that ends with "/mirrorsharp").</summary>
+        public string? WebSocketUrl { get; set; }
+
         /// <summary>Disables C# — the language will not be available to the client.</summary>
         /// <returns>Current <see cref="MirrorSharpOptions" /> object, for convenience.</returns>
         public MirrorSharpOptions DisableCSharp() {


### PR DESCRIPTION
- Allow developer to set a custom web socket url
- Default behavior does not break current usages
- Default behavior allows more usages whose URL ends with "/mirrorsharp"
- When a WebSocketUrl is set, it is used instead of the default behaviour
- We are lenient with the case of the URL 
- We are lenient with leading or following spaces

[ISSUE] https://github.com/ashmind/mirrorsharp/issues/110