### PR TITLE
Call the public `setServerOptions` method in the demos

### DIFF
--- a/AspNetCore.Demo/app.js
+++ b/AspNetCore.Demo/app.js
@@ -22,4 +22,4 @@ const ms = mirrorsharp(textarea, {
     language: language
 });
 if (mode !== 'regular')
-    ms.sendServerOptions({ 'language': language, 'x-mode': mode });
+    ms.setServerOptions({ 'language': language, 'x-mode': mode });

--- a/Owin.Demo/app.js
+++ b/Owin.Demo/app.js
@@ -22,4 +22,4 @@ const ms = mirrorsharp(textarea, {
     language: language
 });
 if (mode !== 'regular')
-    ms.sendServerOptions({ 'language': language, 'x-mode': mode });
+    ms.setServerOptions({ 'language': language, 'x-mode': mode });


### PR DESCRIPTION
`sendServerOptions` is a private method as seen here: https://github.com/ashmind/mirrorsharp/blob/78c4e57471c7ee0c7ea1d9e39ee1910da705b17e/WebAssets/ts/main/editor.ts#L500

The existing code causes a JavaScript error. This change corrects the behavior.