### PR TITLE
Fix the WebAssets build when using Node.js 13+

### DIFF
--- a/WebAssets/build.ts
+++ b/WebAssets/build.ts
@@ -34,9 +34,14 @@ const ts = task('ts', async () => {
 
 const css = task('css', () => jetpack.copyAsync('css', 'dist', { overwrite: true }), { inputs: ['css/*.*'] });
 
-const files = task('files', () => {
-    jetpack.copyAsync('./README.md', 'dist/README.md', { overwrite: true });
-    jetpack.copyAsync('./package.json', 'dist/package.json', { overwrite: true });
+const files = task('files', async () => {
+    await jetpack.copyAsync('./README.md', 'dist/README.md', { overwrite: true });
+    const packageJson = JSON.parse((await jetpack.readAsync('./package.json'))!);
+    // cannot be specified in current package.json due to https://github.com/TypeStrong/ts-node/issues/935
+    // which is fine, from perspective of the project itself it's TypeScript, so type=module is irrelevant
+    // only the output (dist) is JS modules
+    packageJson.type = 'module';
+    await jetpack.writeAsync('dist/package.json', JSON.stringify(packageJson, null, 4));
 }, { inputs: ['./README.md', './package.json'] });
 
 task('default', async () => {

--- a/WebAssets/package.json
+++ b/WebAssets/package.json
@@ -1,7 +1,6 @@
 {
     "name": "mirrorsharp",
     "version": "2.0.0",
-    "type": "module",
     "engines": {
         "node": ">=12.6.1"
     },


### PR DESCRIPTION
When I run `npm run-script build` in the `WebAssets` directory, the build fails with the following error. I'm using node v14.0.0.

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/haacked/dev/haacked/mirrorsharp/WebAssets/build.ts
    at Loader.defaultGetFormat [as _getFormat] (internal/modules/esm/get_format.js:65:15)
    at Loader.getFormat (internal/modules/esm/loader.js:113:42)
    at Loader.getModuleJob (internal/modules/esm/loader.js:244:31)
    at Loader.import (internal/modules/esm/loader.js:178:17)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! mirrorsharp@2.0.0 build: `ts-node-script ./build.ts`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the mirrorsharp@2.0.0 build script.
```

It turns out there's an issue using ts-node when ES Modules are in the dependency graph in Node.js 13+. See this issue for more details: https://github.com/TypeStrong/ts-node/issues/935

The fix is to remove the `"type": "module"` line. I'm not exactly sure what downstream effects this might have, but it makes the build work.