### PR TITLE
Add wwwroot and .idea folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ obj/
 /WebAssets/coverage
 /Owin.Demo/wwwroot
 /AspNetCore.Demo/wwwroot
+/AspNetCore.Demo/dist
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.user
 project.lock.json
 .vs/
+.idea/
 bower_components/
 node_modules/
 .cache/
@@ -11,5 +12,3 @@ obj/
 /WebAssets/coverage
 /Owin.Demo/wwwroot
 /AspNetCore.Demo/wwwroot
-/AspNetCore.Demo/dist
-.idea/


### PR DESCRIPTION
In the project `AspNetCore.Demo`, the content of the `wwwroot` and `dist` folders are generated by the build. The contents probably shouldn't be committed to the repository, so this PR adds those folders to the `.gitignore` file.

This also adds the `.idea` folder to `.gitignore` for those rare folks using Rider. :smile: