### PR TITLE
update API surface area for FCS 40

### DIFF
--- a/FSharp/Advanced/FSharpParseAndCheckResults.cs
+++ b/FSharp/Advanced/FSharpParseAndCheckResults.cs
@@ -1,4 +1,4 @@
-using FSharp.Compiler.SourceCodeServices;
+using FSharp.Compiler.CodeAnalysis;
 
 namespace MirrorSharp.FSharp.Advanced {
     /// <summary>Represent combined Parse and Check results from the <see cref="FSharpChecker" />.</summary>

--- a/FSharp/Advanced/FSharpProjectOptionsExtensions.cs
+++ b/FSharp/Advanced/FSharpProjectOptionsExtensions.cs
@@ -1,14 +1,14 @@
 using System;
 using System.Collections.Generic;
-using FSharp.Compiler.SourceCodeServices;
+using FSharp.Compiler.CodeAnalysis;
 using MirrorSharp.Internal;
 
 namespace MirrorSharp.FSharp.Advanced {
     /// <summary>Provides Roslyn-like extensions that allow simple updates to <see cref="FSharpProjectOptions" />.</summary>
     public static class FSharpProjectOptionsExtensions {
         /// <summary>
-        /// Returns a new instance of <see cref="FSharpProjectOptions" /> with 
-        /// <see cref="FSharpProjectOptions.OtherOptions"/> <c>--debug</c> option set to the provided value; if 
+        /// Returns a new instance of <see cref="FSharpProjectOptions" /> with
+        /// <see cref="FSharpProjectOptions.OtherOptions"/> <c>--debug</c> option set to the provided value; if
         /// it already matches the provided value, returns <paramref name="options" />.
         /// </summary>
         /// <param name="options">The options to use as a base for the returned value.</param>
@@ -24,8 +24,8 @@ namespace MirrorSharp.FSharp.Advanced {
         }
 
         /// <summary>
-        /// Returns a new instance of <see cref="FSharpProjectOptions" /> with 
-        /// <see cref="FSharpProjectOptions.OtherOptions"/> <c>--optimize</c> option set to the provided value; if 
+        /// Returns a new instance of <see cref="FSharpProjectOptions" /> with
+        /// <see cref="FSharpProjectOptions.OtherOptions"/> <c>--optimize</c> option set to the provided value; if
         /// it already matches the provided value, returns <paramref name="options" />.
         /// </summary>
         /// <param name="options">The options to use as a base for the returned value.</param>
@@ -41,8 +41,8 @@ namespace MirrorSharp.FSharp.Advanced {
         }
 
         /// <summary>
-        /// Returns a new instance of <see cref="FSharpProjectOptions" /> with 
-        /// <see cref="FSharpProjectOptions.OtherOptions"/> <c>--target</c> option set to the provided value; if 
+        /// Returns a new instance of <see cref="FSharpProjectOptions" /> with
+        /// <see cref="FSharpProjectOptions.OtherOptions"/> <c>--target</c> option set to the provided value; if
         /// it already matches the provided value, returns <paramref name="options" />.
         /// </summary>
         /// <param name="options">The options to use as a base for the returned value.</param>
@@ -58,7 +58,7 @@ namespace MirrorSharp.FSharp.Advanced {
         }
 
         /// <summary>
-        /// Returns a new instance of <see cref="FSharpProjectOptions" /> with 
+        /// Returns a new instance of <see cref="FSharpProjectOptions" /> with
         /// <see cref="FSharpProjectOptions.OtherOptions"/> <c>--define</c>:<paramref name="symbol"/> option
         /// added or removed depending on <paramref name="defined"/>; if it already matches the provided
         /// value, returns <paramref name="options" />.
@@ -78,8 +78,8 @@ namespace MirrorSharp.FSharp.Advanced {
         }
 
         /// <summary>
-        /// Returns a new instance of <see cref="FSharpProjectOptions" /> with 
-        /// <see cref="FSharpProjectOptions.OtherOptions"/> set to the provided value; if 
+        /// Returns a new instance of <see cref="FSharpProjectOptions" /> with
+        /// <see cref="FSharpProjectOptions.OtherOptions"/> set to the provided value; if
         /// it is already the same as the provided value, returns <paramref name="options" />.
         /// </summary>
         /// <param name="options">The options to use as a base for the returned value.</param>
@@ -106,7 +106,6 @@ namespace MirrorSharp.FSharp.Advanced {
                 options.LoadTime,
                 options.UnresolvedReferences,
                 options.OriginalLoadReferences,
-                options.ExtraProjectInfo,
                 options.Stamp
             );
         }

--- a/FSharp/Advanced/FSharpTargetNames.cs
+++ b/FSharp/Advanced/FSharpTargetNames.cs
@@ -1,4 +1,4 @@
-using FSharp.Compiler.SourceCodeServices;
+using FSharp.Compiler.CodeAnalysis;
 
 namespace MirrorSharp.FSharp.Advanced {
     /// <summary>

--- a/FSharp/Advanced/IFSharpSession.cs
+++ b/FSharp/Advanced/IFSharpSession.cs
@@ -21,10 +21,10 @@ namespace MirrorSharp.FSharp.Advanced {
         /// <returns>Last <see cref="FSharpCheckFileAnswer"/> if still valid, otherwise <c>null</c>.</returns>
         FSharpCheckFileAnswer? GetLastCheckAnswer();
 
-        /// <summary>Converts <see cref="FSharpErrorInfo" /> to a <see cref="Diagnostic" />.</summary>
-        /// <param name="error"><see cref="FSharpErrorInfo" /> value to convert.</param>
-        /// <returns><see cref="Diagnostic" /> value that corresponds to <paramref name="error" />.</returns>
-        Diagnostic ConvertToDiagnostic(FSharpErrorInfo error);
+        /// <summary>Converts <see cref="FSharpDiagnostic" /> to a <see cref="Diagnostic" />.</summary>
+        /// <param name="diagnostic"><see cref="FSharpDiagnostic" /> value to convert.</param>
+        /// <returns><see cref="Diagnostic" /> value that corresponds to <paramref name="diagnostic" />.</returns>
+        Diagnostic ConvertToDiagnostic(FSharpDiagnostic diagnostic);
 
         /// <summary>Converts line and column into a text offset.</summary>
         /// <param name="line">Line to convert (0-based).</param>

--- a/FSharp/Advanced/IFSharpSession.cs
+++ b/FSharp/Advanced/IFSharpSession.cs
@@ -3,7 +3,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.FSharp.Collections;
-using FSharp.Compiler.SourceCodeServices;
+using FSharp.Compiler.CodeAnalysis;
+using FSharp.Compiler.Diagnostics;
 
 namespace MirrorSharp.FSharp.Advanced {
     /// <summary>Represents a user session based on F# parser.</summary>

--- a/FSharp/CHANGELOG.md
+++ b/FSharp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.20.1] - 2020-06-23
+
+### Added
+- Updated to support FSharp.Compiler.Service version 40 by @baronfel
+
 ## [0.20.0] - 2020-12-21
 
 ### Added

--- a/FSharp/FSharp.csproj
+++ b/FSharp/FSharp.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
-    <PackageReference Include="FSharp.Compiler.Service" Version="39.0.0" />
-    <PackageReference Include="FSharp.Core" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
+    <PackageReference Include="FSharp.Compiler.Service" Version="40.0.0" />
+    <PackageReference Include="FSharp.Core" Version="5.0.2" />
   </ItemGroup>
 
 </Project>

--- a/FSharp/FSharp.csproj
+++ b/FSharp/FSharp.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
-    <PackageReference Include="FSharp.Compiler.Service" Version="38.0.0" />
-    <PackageReference Include="FSharp.Core" Version="5.0.0" />
+    <PackageReference Include="FSharp.Compiler.Service" Version="39.0.0" />
+    <PackageReference Include="FSharp.Core" Version="5.0.1" />
   </ItemGroup>
 
 </Project>

--- a/FSharp/FSharp.csproj
+++ b/FSharp/FSharp.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>MirrorSharp.FSharp</AssemblyName>
     <RootNamespace>MirrorSharp.FSharp</RootNamespace>
     <TargetFrameworks>netstandard2.0; net461</TargetFrameworks>
-    <VersionPrefix>0.20</VersionPrefix>
+    <VersionPrefix>0.21</VersionPrefix>
     <Description>MirrorSharp F# support library. $(DescriptionSuffix)</Description>
     <PackageTags>F#;CodeMirror</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/FSharp/Internal/CustomFileSystem.cs
+++ b/FSharp/Internal/CustomFileSystem.cs
@@ -2,18 +2,18 @@ using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Reflection;
-using FSharp.Compiler.AbstractIL.Internal;
+using FSharp.Compiler.SourceCodeServices;
 using MirrorSharp.FSharp.Advanced;
 using MirrorSharp.Internal;
 
 namespace MirrorSharp.FSharp.Internal {
-    internal class CustomFileSystem : Library.Shim.IFileSystem {
+    internal class CustomFileSystem : IFileSystem {
         private const string VirtualTempPath = @"V:\virtualfs#temp\";
 
         private readonly ConcurrentDictionary<string, FSharpVirtualFile> _virtualFiles = new ConcurrentDictionary<string, FSharpVirtualFile>();
         private readonly ConcurrentDictionary<string, byte[]> _fileBytesCache = new ConcurrentDictionary<string, byte[]>();
         private readonly ConcurrentDictionary<string, bool> _fileExistsCache = new ConcurrentDictionary<string, bool>();
-        
+
         public static CustomFileSystem Instance { get; } = new CustomFileSystem();
 
         private CustomFileSystem() {

--- a/FSharp/Internal/CustomFileSystem.cs
+++ b/FSharp/Internal/CustomFileSystem.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Reflection;
-using FSharp.Compiler.SourceCodeServices;
+using FSharp.Compiler.IO;
 using MirrorSharp.FSharp.Advanced;
 using MirrorSharp.Internal;
 

--- a/FSharp/Internal/FSharpLanguage.cs
+++ b/FSharp/Internal/FSharpLanguage.cs
@@ -1,4 +1,4 @@
-using FSharp.Compiler.AbstractIL.Internal;
+using FSharp.Compiler.SourceCodeServices;
 using MirrorSharp.Internal;
 using MirrorSharp.Internal.Abstraction;
 
@@ -9,7 +9,7 @@ namespace MirrorSharp.FSharp.Internal {
         private readonly MirrorSharpFSharpOptions _options;
 
         static FSharpLanguage() {
-            Library.Shim.FileSystem = CustomFileSystem.Instance;
+            FileSystemAutoOpens.FileSystem = CustomFileSystem.Instance;
         }
 
         public FSharpLanguage(MirrorSharpFSharpOptions options) {

--- a/FSharp/Internal/FSharpLanguage.cs
+++ b/FSharp/Internal/FSharpLanguage.cs
@@ -1,4 +1,4 @@
-using FSharp.Compiler.SourceCodeServices;
+using FSharp.Compiler.IO;
 using MirrorSharp.Internal;
 using MirrorSharp.Internal.Abstraction;
 

--- a/FSharp/Internal/SymbolTags.cs
+++ b/FSharp/Internal/SymbolTags.cs
@@ -1,5 +1,5 @@
 using System.Collections.Immutable;
-using FSharp.Compiler.SourceCodeServices;
+using FSharp.Compiler.Symbols;
 
 namespace MirrorSharp.FSharp.Internal {
     internal static class SymbolTags {
@@ -12,7 +12,7 @@ namespace MirrorSharp.FSharp.Internal {
         private static ImmutableArray<string> Class { get; } = ImmutableArray.Create("Class");
         private static ImmutableArray<string> Interface { get; } = ImmutableArray.Create("Interface");
         private static ImmutableArray<string> Module { get; } = ImmutableArray.Create("Module");
-            
+
         private static ImmutableArray<string> Property { get; } = ImmutableArray.Create("Property");
         private static ImmutableArray<string> Method { get; } = ImmutableArray.Create("Method");
         private static ImmutableArray<string> Field { get; } = ImmutableArray.Create("Field");

--- a/FSharp/MirrorSharpFSharpOptions.cs
+++ b/FSharp/MirrorSharpFSharpOptions.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using FSharp.Compiler.SourceCodeServices;
+using FSharp.Compiler.CodeAnalysis;
 using Microsoft.FSharp.Core;
 using System.IO;
 

--- a/FSharp/PublicAPI.Shipped.txt
+++ b/FSharp/PublicAPI.Shipped.txt
@@ -1,8 +1,8 @@
 #nullable enable
 MirrorSharp.FSharp.Advanced.FSharpFileSystem
 MirrorSharp.FSharp.Advanced.FSharpParseAndCheckResults
-MirrorSharp.FSharp.Advanced.FSharpParseAndCheckResults.CheckAnswer.get -> FSharp.Compiler.SourceCodeServices.FSharpCheckFileAnswer!
-MirrorSharp.FSharp.Advanced.FSharpParseAndCheckResults.ParseResults.get -> FSharp.Compiler.SourceCodeServices.FSharpParseFileResults!
+MirrorSharp.FSharp.Advanced.FSharpParseAndCheckResults.CheckAnswer.get -> FSharp.Compiler.CodeAnalysis.FSharpCheckFileAnswer!
+MirrorSharp.FSharp.Advanced.FSharpParseAndCheckResults.ParseResults.get -> FSharp.Compiler.CodeAnalysis.FSharpParseFileResults!
 MirrorSharp.FSharp.Advanced.FSharpProjectOptionsExtensions
 MirrorSharp.FSharp.Advanced.FSharpTargets
 MirrorSharp.FSharp.Advanced.FSharpVirtualFile
@@ -12,13 +12,13 @@ MirrorSharp.FSharp.Advanced.FSharpVirtualFile.Stream.get -> System.IO.MemoryStre
 MirrorSharp.FSharp.Advanced.IFSharpSession
 MirrorSharp.FSharp.Advanced.IFSharpSession.AssemblyReferencePaths.get -> System.Collections.Immutable.ImmutableArray<string!>
 MirrorSharp.FSharp.Advanced.IFSharpSession.AssemblyReferencePathsAsFSharpList.get -> Microsoft.FSharp.Collections.FSharpList<string!>!
-MirrorSharp.FSharp.Advanced.IFSharpSession.Checker.get -> FSharp.Compiler.SourceCodeServices.FSharpChecker!
-MirrorSharp.FSharp.Advanced.IFSharpSession.ConvertToDiagnostic(FSharp.Compiler.SourceCodeServices.FSharpDiagnostic! diagnostic) -> Microsoft.CodeAnalysis.Diagnostic!
+MirrorSharp.FSharp.Advanced.IFSharpSession.Checker.get -> FSharp.Compiler.CodeAnalysis.FSharpChecker!
+MirrorSharp.FSharp.Advanced.IFSharpSession.ConvertToDiagnostic(FSharp.Compiler.Diagnostics.FSharpDiagnostic! diagnostic) -> Microsoft.CodeAnalysis.Diagnostic!
 MirrorSharp.FSharp.Advanced.IFSharpSession.ConvertToOffset(int line, int column) -> int
-MirrorSharp.FSharp.Advanced.IFSharpSession.GetLastCheckAnswer() -> FSharp.Compiler.SourceCodeServices.FSharpCheckFileAnswer?
-MirrorSharp.FSharp.Advanced.IFSharpSession.GetLastParseResults() -> FSharp.Compiler.SourceCodeServices.FSharpParseFileResults?
+MirrorSharp.FSharp.Advanced.IFSharpSession.GetLastCheckAnswer() -> FSharp.Compiler.CodeAnalysis.FSharpCheckFileAnswer?
+MirrorSharp.FSharp.Advanced.IFSharpSession.GetLastParseResults() -> FSharp.Compiler.CodeAnalysis.FSharpParseFileResults?
 MirrorSharp.FSharp.Advanced.IFSharpSession.ParseAndCheckAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<MirrorSharp.FSharp.Advanced.FSharpParseAndCheckResults!>
-MirrorSharp.FSharp.Advanced.IFSharpSession.ProjectOptions.get -> FSharp.Compiler.SourceCodeServices.FSharpProjectOptions!
+MirrorSharp.FSharp.Advanced.IFSharpSession.ProjectOptions.get -> FSharp.Compiler.CodeAnalysis.FSharpProjectOptions!
 MirrorSharp.FSharp.Advanced.IFSharpSession.ProjectOptions.set -> void
 MirrorSharp.FSharp.Advanced.WorkSessionExtensions
 MirrorSharp.FSharp.MirrorSharpFSharpOptions
@@ -40,11 +40,11 @@ const MirrorSharp.FSharp.Advanced.FSharpTargets.Library = "library" -> string!
 const MirrorSharp.FSharp.Advanced.FSharpTargets.Module = "module" -> string!
 const MirrorSharp.FSharp.Advanced.FSharpTargets.WinExe = "winexe" -> string!
 static MirrorSharp.FSharp.Advanced.FSharpFileSystem.RegisterVirtualFile(System.IO.MemoryStream! stream) -> MirrorSharp.FSharp.Advanced.FSharpVirtualFile!
-static MirrorSharp.FSharp.Advanced.FSharpProjectOptionsExtensions.WithOtherOptionDebug(this FSharp.Compiler.SourceCodeServices.FSharpProjectOptions! options, bool? debug) -> FSharp.Compiler.SourceCodeServices.FSharpProjectOptions!
-static MirrorSharp.FSharp.Advanced.FSharpProjectOptionsExtensions.WithOtherOptionDefine(this FSharp.Compiler.SourceCodeServices.FSharpProjectOptions! options, string! symbol, bool defined = true) -> FSharp.Compiler.SourceCodeServices.FSharpProjectOptions!
-static MirrorSharp.FSharp.Advanced.FSharpProjectOptionsExtensions.WithOtherOptionOptimize(this FSharp.Compiler.SourceCodeServices.FSharpProjectOptions! options, bool? optimize) -> FSharp.Compiler.SourceCodeServices.FSharpProjectOptions!
-static MirrorSharp.FSharp.Advanced.FSharpProjectOptionsExtensions.WithOtherOptionTarget(this FSharp.Compiler.SourceCodeServices.FSharpProjectOptions! options, string? target) -> FSharp.Compiler.SourceCodeServices.FSharpProjectOptions!
-static MirrorSharp.FSharp.Advanced.FSharpProjectOptionsExtensions.WithOtherOptions(this FSharp.Compiler.SourceCodeServices.FSharpProjectOptions! options, string![]! otherOptions) -> FSharp.Compiler.SourceCodeServices.FSharpProjectOptions!
+static MirrorSharp.FSharp.Advanced.FSharpProjectOptionsExtensions.WithOtherOptionDebug(this FSharp.Compiler.CodeAnalysis.FSharpProjectOptions! options, bool? debug) -> FSharp.Compiler.CodeAnalysis.FSharpProjectOptions!
+static MirrorSharp.FSharp.Advanced.FSharpProjectOptionsExtensions.WithOtherOptionDefine(this FSharp.Compiler.CodeAnalysis.FSharpProjectOptions! options, string! symbol, bool defined = true) -> FSharp.Compiler.CodeAnalysis.FSharpProjectOptions!
+static MirrorSharp.FSharp.Advanced.FSharpProjectOptionsExtensions.WithOtherOptionOptimize(this FSharp.Compiler.CodeAnalysis.FSharpProjectOptions! options, bool? optimize) -> FSharp.Compiler.CodeAnalysis.FSharpProjectOptions!
+static MirrorSharp.FSharp.Advanced.FSharpProjectOptionsExtensions.WithOtherOptionTarget(this FSharp.Compiler.CodeAnalysis.FSharpProjectOptions! options, string? target) -> FSharp.Compiler.CodeAnalysis.FSharpProjectOptions!
+static MirrorSharp.FSharp.Advanced.FSharpProjectOptionsExtensions.WithOtherOptions(this FSharp.Compiler.CodeAnalysis.FSharpProjectOptions! options, string![]! otherOptions) -> FSharp.Compiler.CodeAnalysis.FSharpProjectOptions!
 static MirrorSharp.FSharp.Advanced.WorkSessionExtensions.FSharp(this MirrorSharp.Advanced.IWorkSession! session) -> MirrorSharp.FSharp.Advanced.IFSharpSession!
 static MirrorSharp.FSharp.Advanced.WorkSessionExtensions.IsFSharp(this MirrorSharp.Advanced.IWorkSession! session) -> bool
 static MirrorSharp.MirrorSharpOptionsExtensions.EnableFSharp(this MirrorSharp.MirrorSharpOptions! options, System.Action<MirrorSharp.FSharp.MirrorSharpFSharpOptions!>? setup = null) -> MirrorSharp.MirrorSharpOptions!

--- a/FSharp/PublicAPI.Shipped.txt
+++ b/FSharp/PublicAPI.Shipped.txt
@@ -13,7 +13,7 @@ MirrorSharp.FSharp.Advanced.IFSharpSession
 MirrorSharp.FSharp.Advanced.IFSharpSession.AssemblyReferencePaths.get -> System.Collections.Immutable.ImmutableArray<string!>
 MirrorSharp.FSharp.Advanced.IFSharpSession.AssemblyReferencePathsAsFSharpList.get -> Microsoft.FSharp.Collections.FSharpList<string!>!
 MirrorSharp.FSharp.Advanced.IFSharpSession.Checker.get -> FSharp.Compiler.SourceCodeServices.FSharpChecker!
-MirrorSharp.FSharp.Advanced.IFSharpSession.ConvertToDiagnostic(FSharp.Compiler.SourceCodeServices.FSharpErrorInfo! error) -> Microsoft.CodeAnalysis.Diagnostic!
+MirrorSharp.FSharp.Advanced.IFSharpSession.ConvertToDiagnostic(FSharp.Compiler.SourceCodeServices.FSharpDiagnostic! diagnostic) -> Microsoft.CodeAnalysis.Diagnostic!
 MirrorSharp.FSharp.Advanced.IFSharpSession.ConvertToOffset(int line, int column) -> int
 MirrorSharp.FSharp.Advanced.IFSharpSession.GetLastCheckAnswer() -> FSharp.Compiler.SourceCodeServices.FSharpCheckFileAnswer?
 MirrorSharp.FSharp.Advanced.IFSharpSession.GetLastParseResults() -> FSharp.Compiler.SourceCodeServices.FSharpParseFileResults?

--- a/Tests/FSharpProjectOptionsExtensionsTests.cs
+++ b/Tests/FSharpProjectOptionsExtensionsTests.cs
@@ -1,9 +1,10 @@
 using System;
 using Microsoft.FSharp.Collections;
-using FSharp.Compiler.SourceCodeServices;
+using FSharp.Compiler.CodeAnalysis;
 using MirrorSharp.FSharp.Advanced;
 using Xunit;
 using range = FSharp.Compiler.Text.Range;
+using Microsoft.FSharp.Core;
 
 namespace MirrorSharp.Tests {
     public class FSharpProjectOptionsExtensionsTests {
@@ -96,17 +97,16 @@ namespace MirrorSharp.Tests {
         private FSharpProjectOptions NewOptions(string[]? otherOptions = null) {
             return new FSharpProjectOptions(
                 "_",
-                null,
+                FSharpOption<string>.None,
                 new string[0],
                 otherOptions,
-                null,
+                Array.Empty<FSharpReferencedProject>(),
                 false,
                 false,
                 DateTime.MinValue,
-                null,
+                FSharpOption<FSharpUnresolvedReferencesSet>.None,
                 FSharpList<Tuple<range, string, string>>.Empty,
-                null,
-                null
+                FSharpOption<long>.None
             );
         }
     }

--- a/Tests/FSharpProjectOptionsExtensionsTests.cs
+++ b/Tests/FSharpProjectOptionsExtensionsTests.cs
@@ -1,9 +1,9 @@
 using System;
 using Microsoft.FSharp.Collections;
-using FSharp.Compiler;
 using FSharp.Compiler.SourceCodeServices;
 using MirrorSharp.FSharp.Advanced;
 using Xunit;
+using range = FSharp.Compiler.Text.Range;
 
 namespace MirrorSharp.Tests {
     public class FSharpProjectOptionsExtensionsTests {
@@ -104,7 +104,7 @@ namespace MirrorSharp.Tests {
                 false,
                 DateTime.MinValue,
                 null,
-                FSharpList<Tuple<global::FSharp.Compiler.Range.range, string, string>>.Empty,
+                FSharpList<Tuple<range, string, string>>.Empty,
                 null,
                 null
             );


### PR DESCRIPTION
This updates to FCS 40 for F# 5.0 syntax support, in addition to adapting to a few API usage differences as the team has standardized terminology and pulled a few APIs off of the Reactor thread.