### PR TITLE
Exposing Common internals to IL library

### DIFF
--- a/Common/CHANGELOG.md
+++ b/Common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.8] - 2021-09-03
+
+### Fixed
+- Internals visible for a new MirrorSharp.IL library
+
 ## [2.2.7] - 2021-05-07
 
 ### Fixed

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>MirrorSharp.Common</AssemblyName>
     <RootNamespace>MirrorSharp</RootNamespace>
     <TargetFrameworks>netstandard2.0; netcoreapp3.0</TargetFrameworks>
-    <VersionPrefix>2.2.7</VersionPrefix>
+    <VersionPrefix>2.2.8</VersionPrefix>
     <Description>MirrorSharp shared server library. $(DescriptionSuffix)</Description>
     <PackageTags>Roslyn;CodeMirror</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Without it WebServer crashes:

```
crit: Microsoft.AspNetCore.Hosting.Diagnostics[6]
      Application startup exception
      System.TypeLoadException: Type 'MirrorSharp.IL.Internal.ILLanguage' from assembly 'MirrorSharp.IL, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null' is attempting to implement an inaccessible interface.
         at MirrorSharp.MirrorSharpOptionsExtensions.EnableIL(MirrorSharpOptions options, Action`1 setup)
```