### PR TITLE
Bump F# packages for the .NET 9 release

### DIFF
--- a/AspNetCore.Demo.Net6/packages.lock.json
+++ b/AspNetCore.Demo.Net6/packages.lock.json
@@ -73,23 +73,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -575,8 +575,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA==",
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
@@ -893,10 +893,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
-          "System.Collections.Immutable": "7.0.0"
+          "System.Collections.Immutable": "8.0.0"
         }
       },
       "System.Reflection.Primitives": {
@@ -1307,7 +1307,7 @@
       "MirrorSharp.AspNetCore": {
         "type": "Project",
         "dependencies": {
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.AspNetCore.Demo.Library": {
@@ -1328,17 +1328,17 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.IL": {
         "type": "Project",
         "dependencies": {
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Mobius.ILasm": "[0.1.0, )",
           "System.Drawing.Common": "[9.0.0, )"
         }

--- a/AspNetCore.Demo/packages.lock.json
+++ b/AspNetCore.Demo/packages.lock.json
@@ -4,23 +4,23 @@
     ".NETCoreApp,Version=v3.1": {
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
@@ -519,8 +519,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA==",
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ==",
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -819,10 +819,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
-          "System.Collections.Immutable": "7.0.0",
+          "System.Collections.Immutable": "8.0.0",
           "System.Memory": "4.5.5"
         }
       },
@@ -1228,7 +1228,7 @@
       "MirrorSharp.AspNetCore": {
         "type": "Project",
         "dependencies": {
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.AspNetCore.Demo.Library": {
@@ -1249,17 +1249,17 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.IL": {
         "type": "Project",
         "dependencies": {
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Mobius.ILasm": "[0.1.0, )",
           "System.Drawing.Common": "[9.0.0, )"
         }

--- a/FSharp/Advanced/IFSharpSession.cs
+++ b/FSharp/Advanced/IFSharpSession.cs
@@ -28,7 +28,7 @@ namespace MirrorSharp.FSharp.Advanced {
         /// <param name="assemblyStream">Stream to compile the assembly to.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the call.</param>
         /// <returns>A tuple returned from the F# compilation call.</returns>
-        ValueTask<Tuple<FSharpDiagnostic[], int>> CompileAsync(MemoryStream assemblyStream, CancellationToken cancellationToken);
+        ValueTask<Tuple<FSharpDiagnostic[], System.Exception?>> CompileAsync(MemoryStream assemblyStream, CancellationToken cancellationToken);
 
         /// <summary>Converts <see cref="FSharpDiagnostic" /> to a <see cref="Diagnostic" />.</summary>
         /// <param name="diagnostic"><see cref="FSharpDiagnostic" /> value to convert.</param>

--- a/FSharp/FSharp.csproj
+++ b/FSharp/FSharp.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.12.6" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
-    <PackageReference Include="FSharp.Compiler.Service" Version="43.9.101" />
-    <PackageReference Include="FSharp.Core" Version="9.0.101" />
+    <PackageReference Include="FSharp.Compiler.Service" Version="43.9.201" />
+    <PackageReference Include="FSharp.Core" Version="9.0.201" />
   </ItemGroup>
 </Project>

--- a/FSharp/FSharp.csproj
+++ b/FSharp/FSharp.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.12.6" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
-    <PackageReference Include="FSharp.Compiler.Service" Version="43.8.300" />
-    <PackageReference Include="FSharp.Core" Version="8.0.300" />
+    <PackageReference Include="FSharp.Compiler.Service" Version="43.9.101" />
+    <PackageReference Include="FSharp.Core" Version="9.0.101" />
   </ItemGroup>
 </Project>

--- a/FSharp/Internal/CustomFileSystem.cs
+++ b/FSharp/Internal/CustomFileSystem.cs
@@ -24,7 +24,7 @@ namespace MirrorSharp.FSharp.Internal {
             AssemblyLoader = new CustomAssemblyLoader();
         }
 
-        public Stream OpenFileForReadShim(string filePath, FSharpOption<bool> useMemoryMappedFile, FSharpOption<bool> shouldShadowCopy) {
+        public Stream OpenFileForReadShim(string filePath, FSharpOption<bool>? useMemoryMappedFile, FSharpOption<bool>? shouldShadowCopy) {
             if (GetVirtualFile(filePath) is { } virtualFile)
                 return virtualFile.GetStreamWrapper().Reuse();
 
@@ -39,8 +39,8 @@ namespace MirrorSharp.FSharp.Internal {
             return new MemoryStream(_fileBytesCache.GetOrAdd(filePath, f => File.ReadAllBytes(f)));
         }
 
-        public Stream OpenFileForWriteShim(string filePath, FSharpOption<FileMode> fileMode, FSharpOption<FileAccess> fileAccess, FSharpOption<FileShare> fileShare) {
-            if (GetVirtualFile(filePath) is {} virtualFile)
+        public Stream OpenFileForWriteShim(string filePath, FSharpOption<FileMode>? fileMode, FSharpOption<FileAccess>? fileAccess, FSharpOption<FileShare>? fileShare) {
+            if (GetVirtualFile(filePath) is { } virtualFile)
                 return virtualFile.GetStreamWrapper().Reuse();
 
             throw new NotSupportedException();
@@ -75,7 +75,7 @@ namespace MirrorSharp.FSharp.Internal {
         }
 
         public DateTime GetLastWriteTimeShim(string fileName) {
-            if (GetVirtualFile(fileName) is {} virtualFile)
+            if (GetVirtualFile(fileName) is { } virtualFile)
                 return virtualFile.LastWriteTime;
 
             EnsureIsAssemblyFile(fileName);
@@ -86,7 +86,7 @@ namespace MirrorSharp.FSharp.Internal {
         }
 
         public DateTime GetCreationTimeShim(string path) {
-            if (GetVirtualFile(path) is {} virtualFile)
+            if (GetVirtualFile(path) is { } virtualFile)
                 return DateTime.MinValue;
 
             EnsureIsAssemblyFile(path);

--- a/FSharp/Internal/FSharpSession.cs
+++ b/FSharp/Internal/FSharpSession.cs
@@ -76,16 +76,16 @@ internal class FSharpSession : ILanguageSessionInternal, IFSharpSession {
         AssemblyReferencePathsAsFSharpList = ToFSharpList(options.AssemblyReferencePaths);
         _projectOptions = new FSharpProjectOptions(
             "_",
-            projectId: null,
+            projectId: FSharpOption<string>.None,
             sourceFiles: new[] { _sourceFile.Path },
             otherOptions: ConvertToOtherOptionsSlow(options),
             referencedProjects: Array.Empty<FSharpReferencedProject>(),
             isIncompleteTypeCheckEnvironment: true,
             useScriptResolutionRules: false,
             loadTime: DateTime.Now,
-            unresolvedReferences: null,
+            unresolvedReferences: FSharpOption<FSharpUnresolvedReferencesSet>.None,
             originalLoadReferences: FSharpList<Tuple<range, string, string>>.Empty,
-            stamp: null
+            stamp: FSharpOption<long>.None
         );
     }
 

--- a/FSharp/PublicAPI.Unshipped.txt
+++ b/FSharp/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-MirrorSharp.FSharp.Advanced.IFSharpSession.CompileAsync(System.IO.MemoryStream! assemblyStream, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Tuple<FSharp.Compiler.Diagnostics.FSharpDiagnostic![]!, int>!>
+MirrorSharp.FSharp.Advanced.IFSharpSession.CompileAsync(System.IO.MemoryStream! assemblyStream, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Tuple<FSharp.Compiler.Diagnostics.FSharpDiagnostic![]!, System.Exception?>!>

--- a/FSharp/packages.lock.json
+++ b/FSharp/packages.lock.json
@@ -4,25 +4,25 @@
     ".NETFramework,Version=v4.6.2": {
       "FSharp.Compiler.Service": {
         "type": "Direct",
-        "requested": "[43.9.101, )",
-        "resolved": "43.9.101",
-        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
+        "requested": "[43.9.201, )",
+        "resolved": "43.9.201",
+        "contentHash": "9aiiJqQykETSSKwwWnItUXTYPsNWNHTIz8vNR0J1vVZXT4CcVQUGebiXZpJXv01UoRpvNBNdIGUViZI5RhccaQ==",
         "dependencies": {
-          "FSharp.Core": "[9.0.101]",
-          "System.Buffers": "4.5.1",
+          "FSharp.Core": "[9.0.201]",
+          "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "8.0.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
           "System.Reflection.Metadata": "8.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "System.Runtime.CompilerServices.Unsafe": "6.1.0"
         }
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[9.0.101, )",
-        "resolved": "9.0.101",
-        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
+        "requested": "[9.0.201, )",
+        "resolved": "9.0.201",
+        "contentHash": "Ozq4T0ISTkqTYJ035XW/JkdDDaXofbykvfyVwkjLSqaDZ/4uNXfpf92cjcMI9lf9CxWqmlWHScViPh/4AvnWcw=="
       },
       "Microsoft.Build.Utilities.Core": {
         "type": "Direct",
@@ -177,8 +177,8 @@
       },
       "System.Buffers": {
         "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+        "resolved": "4.6.0",
+        "contentHash": "lN6tZi7Q46zFzAbRYXTIvfXcyvQQgxnY7Xm6C6xQ9784dEL1amjM6S6Iw4ZpsvesAKnRVsM4scrDQaDqSClkjA=="
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
@@ -290,8 +290,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+        "resolved": "6.1.0",
+        "contentHash": "5o/HZxx6RVqYlhKSq8/zronDkALJZUT2Vz0hx43f0gwe8mwlM0y2nYlqdBwLMzr262Bwvpikeb/yEwkAa5PADg=="
       },
       "System.Security.AccessControl": {
         "type": "Transitive",
@@ -371,25 +371,25 @@
     ".NETStandard,Version=v2.0": {
       "FSharp.Compiler.Service": {
         "type": "Direct",
-        "requested": "[43.9.101, )",
-        "resolved": "43.9.101",
-        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
+        "requested": "[43.9.201, )",
+        "resolved": "43.9.201",
+        "contentHash": "9aiiJqQykETSSKwwWnItUXTYPsNWNHTIz8vNR0J1vVZXT4CcVQUGebiXZpJXv01UoRpvNBNdIGUViZI5RhccaQ==",
         "dependencies": {
-          "FSharp.Core": "[9.0.101]",
-          "System.Buffers": "4.5.1",
+          "FSharp.Core": "[9.0.201]",
+          "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "8.0.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
           "System.Reflection.Metadata": "8.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "System.Runtime.CompilerServices.Unsafe": "6.1.0"
         }
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[9.0.101, )",
-        "resolved": "9.0.101",
-        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
+        "requested": "[9.0.201, )",
+        "resolved": "9.0.201",
+        "contentHash": "Ozq4T0ISTkqTYJ035XW/JkdDDaXofbykvfyVwkjLSqaDZ/4uNXfpf92cjcMI9lf9CxWqmlWHScViPh/4AvnWcw=="
       },
       "Microsoft.Build.Utilities.Core": {
         "type": "Direct",
@@ -656,8 +656,8 @@
       },
       "System.Buffers": {
         "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+        "resolved": "4.6.0",
+        "contentHash": "lN6tZi7Q46zFzAbRYXTIvfXcyvQQgxnY7Xm6C6xQ9784dEL1amjM6S6Iw4ZpsvesAKnRVsM4scrDQaDqSClkjA=="
       },
       "System.Collections": {
         "type": "Transitive",
@@ -1112,8 +1112,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+        "resolved": "6.1.0",
+        "contentHash": "5o/HZxx6RVqYlhKSq8/zronDkALJZUT2Vz0hx43f0gwe8mwlM0y2nYlqdBwLMzr262Bwvpikeb/yEwkAa5PADg=="
       },
       "System.Runtime.Extensions": {
         "type": "Transitive",

--- a/FSharp/packages.lock.json
+++ b/FSharp/packages.lock.json
@@ -4,25 +4,25 @@
     ".NETFramework,Version=v4.6.2": {
       "FSharp.Compiler.Service": {
         "type": "Direct",
-        "requested": "[43.8.300, )",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "requested": "[43.9.101, )",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[8.0.300, )",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "requested": "[9.0.101, )",
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Microsoft.Build.Utilities.Core": {
         "type": "Direct",
@@ -54,6 +54,15 @@
         "contentHash": "uyjY/cqomw1irT4L7lDeg4sJ36MsjHg3wKqpGrBAdzvZaxo85yMF+sAA9RIzTV92fDxuUzjqksMqA0+SNMkMgA==",
         "dependencies": {
           "System.Memory": "4.5.4"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.3"
         }
       },
       "Microsoft.Build.Framework": {
@@ -152,6 +161,11 @@
         "resolved": "17.12.6",
         "contentHash": "w8Ehofqte5bJoR+Fa3f6JwkwFEkGtXxqvQHGOVOSHDzgNVySvL5FSNhavbQSZ864el9c3rjdLPLAtBW8dq6fmg=="
       },
+      "Microsoft.NETFramework.ReferenceAssemblies.net462": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "IzAV30z22ESCeQfxP29oVf4qEo8fBGXLXSU6oacv/9Iqe6PzgHDKCaWfwMBak7bSJQM0F5boXWoZS+kChztRIQ=="
+      },
       "Microsoft.Win32.Registry": {
         "type": "Transitive",
         "resolved": "5.0.0",
@@ -230,8 +244,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA==",
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ==",
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -267,10 +281,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
-          "System.Collections.Immutable": "7.0.0",
+          "System.Collections.Immutable": "8.0.0",
           "System.Memory": "4.5.5"
         }
       },
@@ -357,25 +371,25 @@
     ".NETStandard,Version=v2.0": {
       "FSharp.Compiler.Service": {
         "type": "Direct",
-        "requested": "[43.8.300, )",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "requested": "[43.9.101, )",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[8.0.300, )",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "requested": "[9.0.101, )",
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Microsoft.Build.Utilities.Core": {
         "type": "Direct",
@@ -797,8 +811,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA==",
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ==",
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1049,10 +1063,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
-          "System.Collections.Immutable": "7.0.0",
+          "System.Collections.Immutable": "8.0.0",
           "System.Memory": "4.5.5"
         }
       },

--- a/Owin.Demo/packages.lock.json
+++ b/Owin.Demo/packages.lock.json
@@ -34,23 +34,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
@@ -263,8 +263,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA==",
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ==",
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -300,10 +300,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
-          "System.Collections.Immutable": "7.0.0",
+          "System.Collections.Immutable": "8.0.0",
           "System.Memory": "4.5.5"
         }
       },
@@ -397,18 +397,18 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.Owin": {
         "type": "Project",
         "dependencies": {
           "Microsoft.Owin": "[4.2.2, )",
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Owin": "[1.0.0, )"
         }
       }

--- a/Tests.Roslyn410/packages.lock.json
+++ b/Tests.Roslyn410/packages.lock.json
@@ -141,23 +141,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -787,8 +787,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA=="
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -1762,18 +1762,18 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.Testing": {
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Buffers": "[4.5.1, )"
         }
@@ -1783,7 +1783,7 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.VisualBasic": "[3.3.1, )",
           "Microsoft.CodeAnalysis.VisualBasic.Features": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       }
     }

--- a/Tests.Roslyn411/packages.lock.json
+++ b/Tests.Roslyn411/packages.lock.json
@@ -141,23 +141,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -787,8 +787,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA=="
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -1762,18 +1762,18 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.Testing": {
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Buffers": "[4.5.1, )"
         }
@@ -1783,7 +1783,7 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.VisualBasic": "[3.3.1, )",
           "Microsoft.CodeAnalysis.VisualBasic.Features": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       }
     }

--- a/Tests.Roslyn44/packages.lock.json
+++ b/Tests.Roslyn44/packages.lock.json
@@ -101,23 +101,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -722,8 +722,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA==",
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ==",
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1115,10 +1115,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
-          "System.Collections.Immutable": "7.0.0",
+          "System.Collections.Immutable": "8.0.0",
           "System.Memory": "4.5.5"
         }
       },
@@ -1694,18 +1694,18 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.Testing": {
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Buffers": "[4.5.1, )"
         }
@@ -1715,7 +1715,7 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.VisualBasic": "[3.3.1, )",
           "Microsoft.CodeAnalysis.VisualBasic.Features": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       }
     }

--- a/Tests.Roslyn45/packages.lock.json
+++ b/Tests.Roslyn45/packages.lock.json
@@ -101,23 +101,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -720,8 +720,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA==",
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ==",
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1113,10 +1113,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
-          "System.Collections.Immutable": "7.0.0",
+          "System.Collections.Immutable": "8.0.0",
           "System.Memory": "4.5.5"
         }
       },
@@ -1697,18 +1697,18 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.Testing": {
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Buffers": "[4.5.1, )"
         }
@@ -1718,7 +1718,7 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.VisualBasic": "[3.3.1, )",
           "Microsoft.CodeAnalysis.VisualBasic.Features": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       }
     }

--- a/Tests.Roslyn46/packages.lock.json
+++ b/Tests.Roslyn46/packages.lock.json
@@ -101,23 +101,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -723,8 +723,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA==",
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ==",
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1116,10 +1116,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
-          "System.Collections.Immutable": "7.0.0",
+          "System.Collections.Immutable": "8.0.0",
           "System.Memory": "4.5.5"
         }
       },
@@ -1700,18 +1700,18 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.Testing": {
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Buffers": "[4.5.1, )"
         }
@@ -1721,7 +1721,7 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.VisualBasic": "[3.3.1, )",
           "Microsoft.CodeAnalysis.VisualBasic.Features": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       }
     }

--- a/Tests.Roslyn47/packages.lock.json
+++ b/Tests.Roslyn47/packages.lock.json
@@ -101,23 +101,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -713,8 +713,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA=="
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -1107,10 +1107,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
-          "System.Collections.Immutable": "7.0.0"
+          "System.Collections.Immutable": "8.0.0"
         }
       },
       "System.Reflection.Primitives": {
@@ -1683,18 +1683,18 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.Testing": {
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Buffers": "[4.5.1, )"
         }
@@ -1704,7 +1704,7 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.VisualBasic": "[3.3.1, )",
           "Microsoft.CodeAnalysis.VisualBasic.Features": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       }
     }

--- a/Tests.Roslyn48/packages.lock.json
+++ b/Tests.Roslyn48/packages.lock.json
@@ -101,23 +101,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -713,8 +713,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA=="
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -1107,10 +1107,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
-          "System.Collections.Immutable": "7.0.0"
+          "System.Collections.Immutable": "8.0.0"
         }
       },
       "System.Reflection.Primitives": {
@@ -1683,18 +1683,18 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.Testing": {
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Buffers": "[4.5.1, )"
         }
@@ -1704,7 +1704,7 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.VisualBasic": "[3.3.1, )",
           "Microsoft.CodeAnalysis.VisualBasic.Features": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       }
     }

--- a/Tests.Roslyn49/packages.lock.json
+++ b/Tests.Roslyn49/packages.lock.json
@@ -101,23 +101,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -712,8 +712,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA=="
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -1682,18 +1682,18 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.Testing": {
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Buffers": "[4.5.1, )"
         }
@@ -1703,7 +1703,7 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.VisualBasic": "[3.3.1, )",
           "Microsoft.CodeAnalysis.VisualBasic.Features": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       }
     }

--- a/Tests.RoslynLatest/packages.lock.json
+++ b/Tests.RoslynLatest/packages.lock.json
@@ -153,23 +153,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -850,8 +850,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA=="
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -1825,18 +1825,18 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.Testing": {
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Buffers": "[4.5.1, )"
         }
@@ -1846,7 +1846,7 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.VisualBasic": "[3.3.1, )",
           "Microsoft.CodeAnalysis.VisualBasic.Features": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       }
     }

--- a/Tests/FSharp/FSharpProjectOptionsExtensionsTests.cs
+++ b/Tests/FSharp/FSharpProjectOptionsExtensionsTests.cs
@@ -24,7 +24,7 @@ public class FSharpProjectOptionsExtensionsTests {
     [InlineData(new[] { "--optimize+" }, null, new string[0])]
     [InlineData(new[] { "--optimize-" }, true, new[] { "--optimize+" })]
     [InlineData(new[] { "--optimize-" }, null, new string[0])]
-    [InlineData(new string[0], true,  new[] { "--optimize+" })]
+    [InlineData(new string[0], true, new[] { "--optimize+" })]
     [InlineData(new string[0], false, new[] { "--optimize-" })]
     public void WithOtherOptionOptimize_ReturnsExpectedOptions_IfValueIsNotTheSame(string[] otherOptions, bool? newValue, string[] expected) {
         var options = NewOptions(otherOptions: otherOptions).WithOtherOptionOptimize(newValue);
@@ -46,7 +46,7 @@ public class FSharpProjectOptionsExtensionsTests {
     [Theory]
     [InlineData(new[] { "--target:exe" }, FSharpTargets.Library, new[] { "--target:library" })]
     [InlineData(new[] { "--target:library" }, FSharpTargets.Exe, new[] { "--target:exe" })]
-    [InlineData(new string[0], FSharpTargets.Library,  new[] { "--target:library" })]
+    [InlineData(new string[0], FSharpTargets.Library, new[] { "--target:library" })]
     public void WithOtherOptionTarget_ReturnsExpectedOptions_IfValueIsNotTheSame(string[] otherOptions, string newValue, string[] expected) {
         var options = NewOptions(otherOptions: otherOptions).WithOtherOptionTarget(newValue);
         Assert.Equal(expected, options.OtherOptions);
@@ -78,7 +78,7 @@ public class FSharpProjectOptionsExtensionsTests {
             "_",
             FSharpOption<string>.None,
             new string[0],
-            otherOptions,
+            otherOptions ?? new string[0] { },
             Array.Empty<FSharpReferencedProject>(),
             false,
             false,

--- a/Tests/packages.lock.json
+++ b/Tests/packages.lock.json
@@ -57,23 +57,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "HtmlAgilityPack": {
         "type": "Transitive",
@@ -860,8 +860,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA==",
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ==",
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -1265,10 +1265,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
-          "System.Collections.Immutable": "7.0.0",
+          "System.Collections.Immutable": "8.0.0",
           "System.Memory": "4.5.5"
         }
       },
@@ -1834,17 +1834,17 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.Php": {
         "type": "Project",
         "dependencies": {
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "Peachpie.App": "[0.9.0-CI01101, )",
           "Peachpie.CodeAnalysis": "[0.9.0-CI01101, )",
@@ -1855,7 +1855,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Buffers": "[4.5.1, )"
         }
@@ -1865,7 +1865,7 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.VisualBasic": "[3.3.1, )",
           "Microsoft.CodeAnalysis.VisualBasic.Features": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       }
     },
@@ -1883,6 +1883,15 @@
         "contentHash": "56w1drIQqpMgg3IxHcfra/jXOngiD4pbl0j6TNeJMlOQGlZ8wCMlyRTvn6Crd/FgGjwKbWLurdOHNGrfzLtl6A==",
         "dependencies": {
           "Microsoft.CodeCoverage": "16.2.0"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net471": "1.0.3"
         }
       },
       "SourceMock": {
@@ -1918,23 +1927,23 @@
       },
       "FSharp.Compiler.Service": {
         "type": "Transitive",
-        "resolved": "43.8.300",
-        "contentHash": "CoPjQYXXwmYkkHm+yxBHSW9IJVLpvwkKGEzXa5A6ebf8v6GfYaxZc5G+VHojDr586oezp1elFemu+A1WWH095A==",
+        "resolved": "43.9.101",
+        "contentHash": "Mb7g68UXRLBmeDdrDRpPfjN/HWxTWr9WwqL9lt2PaRPflo8Qg5uxn479Hk4wYCv9dfNEpUy21KZOfCGsNXterw==",
         "dependencies": {
-          "FSharp.Core": "[8.0.300]",
+          "FSharp.Core": "[9.0.101]",
           "System.Buffers": "4.5.1",
-          "System.Collections.Immutable": "7.0.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
           "System.Reflection.Emit": "4.7.0",
-          "System.Reflection.Metadata": "7.0.0",
+          "System.Reflection.Metadata": "8.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "FSharp.Core": {
         "type": "Transitive",
-        "resolved": "8.0.300",
-        "contentHash": "Jv44fV7TNglyMku89lQcA4Q6mFKLyHb2bs1Yb72nvSVc+cHplEnoZ4XQUaaTLJGUTx/iMqcrkYGtaLzkkIhpaA=="
+        "resolved": "9.0.101",
+        "contentHash": "3/YR1SDWFA+Ojx9HiBwND+0UR8ZWoeZfkhD0DWAPCDdr/YI+CyFkArmMGzGSyPXeYtjG0sy0emzfyNwjt7zhig=="
       },
       "HtmlAgilityPack": {
         "type": "Transitive",
@@ -2127,6 +2136,11 @@
         "type": "Transitive",
         "resolved": "17.12.6",
         "contentHash": "w8Ehofqte5bJoR+Fa3f6JwkwFEkGtXxqvQHGOVOSHDzgNVySvL5FSNhavbQSZ864el9c3rjdLPLAtBW8dq6fmg=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net471": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "Kf3vusy+mwHzn+0osmJAMrZNG00/UkwywjwfFKLUWSYEXiIMD6SEMGP9bG3sH1B54IiydxAneLubS5/Ajjn/Tw=="
       },
       "Microsoft.Win32.Registry": {
         "type": "Transitive",
@@ -2367,8 +2381,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "hYr3I9N9811e0Bjf2WNwAGGyTuAFbbTgX1RPLt/3Wbm68x3IGcX5Cl75CMmgT6WlNwLQ2tCCWfqYPpypjaf2xA==",
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ==",
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
@@ -2414,10 +2428,10 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
-          "System.Collections.Immutable": "7.0.0",
+          "System.Collections.Immutable": "8.0.0",
           "System.Memory": "4.5.5"
         }
       },
@@ -2618,17 +2632,17 @@
       "MirrorSharp.FSharp": {
         "type": "Project",
         "dependencies": {
-          "FSharp.Compiler.Service": "[43.8.300, )",
-          "FSharp.Core": "[8.0.300, )",
+          "FSharp.Compiler.Service": "[43.9.101, )",
+          "FSharp.Core": "[9.0.101, )",
           "Microsoft.Build.Utilities.Core": "[17.12.6, )",
           "Microsoft.IO.RecyclableMemoryStream": "[2.2.0, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       },
       "MirrorSharp.Php": {
         "type": "Project",
         "dependencies": {
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "Peachpie.App": "[0.9.0-CI01101, )",
           "Peachpie.CodeAnalysis": "[0.9.0-CI01101, )",
@@ -2639,7 +2653,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeAnalysis.Common": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )",
+          "MirrorSharp.Common": "[3.0.10, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Buffers": "[4.5.1, )"
         }
@@ -2649,7 +2663,7 @@
         "dependencies": {
           "Microsoft.CodeAnalysis.VisualBasic": "[3.3.1, )",
           "Microsoft.CodeAnalysis.VisualBasic.Features": "[3.3.1, )",
-          "MirrorSharp.Common": "[3.0.9, )"
+          "MirrorSharp.Common": "[3.0.10, )"
         }
       }
     }


### PR DESCRIPTION
This updates the F# compiler libraries to the .NET 9 family. There were only minor changes around nullability, because F#9 supports emitting nullability attributes for F# types. All tests are green on my machine after this change.